### PR TITLE
cherry-pick 89af3e4 because 4.2.7 doesn't build without catch2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-all : autoconf avro aws-sdk-cpp boost clang clang-runtime cmake cpython imagemagick jansson json libarchive libs3 mungefs qpid qpid-proton qpid-with-proton redis zeromq4-1 cppzmq epm
+all : autoconf avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cpython imagemagick jansson json libarchive libs3 mungefs qpid qpid-proton qpid-with-proton redis zeromq4-1 cppzmq epm
 
-server : avro boost clang-runtime cppzmq jansson libarchive zeromq4-1
+server : avro boost catch2 clang-runtime cppzmq jansson libarchive zeromq4-1
 
 .PHONY : all server clean $(all)
 
@@ -44,6 +44,14 @@ boost_clean :
 	@echo "Cleaning boost..."
 	@rm -rf boost*
 	@rm -rf $(BOOST_PACKAGE)
+
+$(CATCH2_PACKAGE) :
+	./build.py $(VERBOSITY) catch2 > catch2.log 2>&1
+catch2 : $(CATCH2_PACKAGE)
+catch2_clean :
+	@echo "Cleaning catch2..."
+	@rm -rf catch2*
+	@rm -rf $(CATCH2_PACKAGE)
 
 $(CLANG_PACKAGE) : $(CMAKE_PACKAGE) $(CPYTHON_PACKAGE)
 	./build.py $(VERBOSITY) clang > clang.log 2>&1
@@ -181,7 +189,7 @@ epm_clean :
 	@rm -rf epm*
 	@rm -rf $(EPM_PACKAGE)
 
-clean : autoconf_clean avro_clean aws-sdk-cpp_clean boost_clean clang_clean clang-runtime_clean cmake_clean cpython_clean jansson_clean libarchive_clean libs3_clean mungefs_clean zeromq4-1_clean cppzmq_clean epm_clean
+clean : autoconf_clean avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cpython_clean jansson_clean libarchive_clean libs3_clean mungefs_clean zeromq4-1_clean cppzmq_clean epm_clean
 	@echo "Cleaning generated files..."
 	@rm -rf packages.mk
 	@echo "Done."

--- a/versions.json
+++ b/versions.json
@@ -67,6 +67,21 @@
         ],
         "fpm_directories": ["include","lib"]
     },
+    "catch2": {
+        "commitish": "v2.3.0",
+        "version_string": "2.3.0",
+        "license": "Boost Software License 1.0",
+        "consortium_build_number": "0",
+        "externals_root": "opt/irods-externals",
+        "build_steps": [
+            "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
+            "cp single_include/catch2/catch.hpp TEMPLATE_INSTALL_PREFIX/include"
+            ],
+        "external_build_steps": [
+            "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
+        ],
+        "fpm_directories": ["include"]
+    },
     "clang": {
         "commitish": "release_38",
         "version_string": "3.8",


### PR DESCRIPTION
Currently, 4-2-stable doesn't include all the packages needed to build irods 4.2.7, because the 4.2.7 unit tests depend on catch2, which is not in 4-2-stable. catch2 is in master, so cherry-pick it across, and also add it to the list of server externals which was added in 9ccf28b and 10c80b8, after catch2 was added