### PR TITLE
resolve issue with rvm version mismatch resulting in gem: command not found

### DIFF
--- a/build.py
+++ b/build.py
@@ -16,7 +16,6 @@ import sys
 script_path = os.path.dirname(os.path.realpath(__file__))
 
 ruby_requirements = {
-    'rvm': '2.6',
     'ruby': '2.6.5',
     'path': '/usr/local/rvm/bin'
 }

--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -9,7 +9,7 @@ import os
 import platform
 import sys
 
-RVM_VERSION = build.ruby_requirements['rvm']
+RUBY_VERSION = build.ruby_requirements['ruby']
 RVM_PATH = build.ruby_requirements['path']
 
 def mkdir_p(path):
@@ -26,15 +26,15 @@ def install_rvm_and_ruby():
     build.run_cmd(cmd, unsafe_shell=True, check_rc='gpg keys not received', retries=10)
     cmd = 'curl -sSL https://get.rvm.io | sudo bash -s stable'
     build.run_cmd(cmd, unsafe_shell=True, check_rc='curl failed')
-    cmd = "sudo -E su -c '{rvm_path}/rvm reload && {rvm_path}/rvm requirements run && {rvm_path}/rvm install {rvm_version}'".format(
-        rvm_version = RVM_VERSION,
+    cmd = "sudo -E su -c '{rvm_path}/rvm reload && {rvm_path}/rvm requirements run && {rvm_path}/rvm install {ruby_version}'".format(
+        ruby_version = RUBY_VERSION,
         rvm_path = RVM_PATH )
     build.run_cmd(cmd, unsafe_shell=True, run_env=True, check_rc='rvm ruby install failed')
 
 def install_fpm_gem():
     build.set_ruby_path()
-    cmd = """sudo -E su -c 'PATH="{PATH}"; export PATH; {rvm_path}/rvm reload && {rvm_path}/rvm use {rvm_version} && gem install -v 1.4.0 fpm'""".format(
-        rvm_version = RVM_VERSION,
+    cmd = """sudo -E su -c 'PATH="{PATH}"; export PATH; {rvm_path}/rvm reload && {rvm_path}/rvm use {ruby_version} && gem install -v 1.4.0 fpm'""".format(
+        ruby_version = RUBY_VERSION,
         rvm_path = RVM_PATH,
         PATH = os.environ['PATH'] )
     build.run_cmd(cmd, unsafe_shell=True, run_env=True, check_rc='fpm gem install failed')


### PR DESCRIPTION
using rvm version as well as ruby version means that ruby version needs updating every time rvm add a new entry to the 2.6 stream. This is currently failing, because 2.6.6 gets installed, but 2.6.5 is looked for. rvm can take the patch version, and if we supply it then this problem won't recur when rvm add 2.6.7