### PR TITLE
Add Arch Linux and Python 3.8+ Support to install_prerequisites.py

### DIFF
--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -40,6 +40,19 @@ def install_fpm_gem():
     build.run_cmd(cmd, unsafe_shell=True, run_env=True, check_rc='fpm gem install failed')
 
 
+def get_platform():
+    # linux_distribution() is removed in Python 3.8+, so distro is used as a backup
+    try:
+        pld = platform.linux_distribution()[0]
+        if pld != '':
+            return pld
+    except AttributeError:
+        pass
+    import distro
+    pld = distro.linux_distribution()[0]
+    return pld
+
+
 def main():
     # configure parser
     parser = optparse.OptionParser()
@@ -62,10 +75,7 @@ def main():
     ch.setFormatter(formatter)
     log.addHandler(ch)
 
-    pld = platform.linux_distribution()[0]
-    if pld == '':
-        import distro
-        pld = distro.linux_distribution()[0]
+    pld = get_platform()
 
     if pld in ['debian', 'Ubuntu']:
         log.info('Detected: {0}'.format(pld))
@@ -128,6 +138,15 @@ def main():
                'libopenssl-devel','rpm-build','help2man','python-devel','libbz2-devel','libcurl-devel','libxml2-devel','libtool',
                'libuuid-devel','uuid-devel','unixODBC-devel','cyrus-sasl','patchelf']
         build.run_cmd(cmd, check_rc='installing prerequisites failed')
+
+    elif pld in ['arch', 'Arch', 'Arch Linux', 'Manjaro Linux']:
+        log.info('Detected: {0}'.format(pld))
+        # get prerequisites
+        cmd = ['sudo', 'pacman', '-Sy', '--noconfirm', 'autoconf', 'automake', 'bzip2', 'curl', 'cyrus-sasl', 'fuse2', 'git', 'gzip', 'help2man',
+               'libmicrohttpd', 'libtool', 'libxml2', 'openssl', 'patchelf', 'ruby', 'rubygems', 'tar', 'texinfo', 'unixodbc',
+               'util-linux-libs']
+        build.run_cmd(cmd, check_rc='installing prerequisites failed')
+
     else:
         if platform.mac_ver()[0] != '':
             log.info('Detected: {0}'.format(platform.mac_ver()[0]))


### PR DESCRIPTION
I tested this in both Python 3.5 and Python 3.9 on Manjaro Linux, which is derived from Arch Linux.

Changes made:
1. The linux_distribution function from the platform library was depreciated as of Python 3.5 and removed as of Python 3.8. As such, I've broken that piece out into a get_platform() function that catches the exception when platform.linux_distribution() does not exist.

2. Added a pld check for Arch Linux and Manjaro Linux. The installation command uses "pacman -Sy --noconfirm", which refreshes the packages (similar to apt-get update) and uses the default decision for prompts (like -y does for apt-get).

If any changes are needed, let me know.