### PR TITLE
retrieve keys from rvm.io via curl (4-2-stable)

### DIFF
--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -23,8 +23,10 @@ def mkdir_p(path):
 
 
 def install_rvm_and_ruby():
-    cmd = 'sudo gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB'
-    build.run_cmd(cmd, unsafe_shell=True, check_rc='gpg keys not received', retries=10)
+    cmd = 'curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -'
+    build.run_cmd(cmd, unsafe_shell=True, check_rc='curl failed')
+    cmd = 'curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg --import -'
+    build.run_cmd(cmd, unsafe_shell=True, check_rc='curl failed')
     cmd = 'curl -sSL https://get.rvm.io | sudo bash -s stable'
     build.run_cmd(cmd, unsafe_shell=True, check_rc='curl failed')
     cmd = "sudo -E su -c '{rvm_path}/rvm reload && {rvm_path}/rvm requirements run && {rvm_path}/rvm install {ruby_version}'".format(


### PR DESCRIPTION
  https://sks-keyservers.net/status/ has

```
This service is deprecated. This means it is no longer maintained, and new HKPS certificates will not be issued. Service reliability should not be expected.

Update 2021-06-21: Due to even more GDPR takedown requests, the DNS records for the pool will no longer be provided at all.
```