### PR TITLE
[irods/irods#5860] use DF_ORIGIN and add CPR path to locate other sha…

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -190,12 +190,12 @@
         "commitish": "3adb172a26baae1a995e810e49fee1688ea44df5",
         "version_string": "0.1.0",
         "license": "MIT",
-        "consortium_build_number": "1",
+        "consortium_build_number": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "git submodule update --init --recursive",
             "mkdir -p build",
-            "cd build; rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_INSTALL_RPATH=/TEMPLATE_BOOST_RPATH\\;/TEMPLATE_CLANG_RUNTIME_RPATH -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DBOOST_ROOT=TEMPLATE_BOOST_ROOT -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi -lpthread' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' ..",
+            "cd build; rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_INSTALL_RPATH=/TEMPLATE_BOOST_RPATH\\;/TEMPLATE_CLANG_RUNTIME_RPATH\\;\\$ORIGIN\\;/TEMPLATE_CPR_RPATH -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DBOOST_ROOT=TEMPLATE_BOOST_ROOT -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi -lpthread' -DCMAKE_SHARED_LINKER_FLAGS='-Wl,--enable-new-dtags -Wl,-z,origin -stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' ..",
             "cd build && make",
             "cd build && cp external/httpmockserver/libhttpmockserver.pc ./",
             "cd build && make install"


### PR DESCRIPTION
…red libraries

- Affects the elasticlient library.  Accordingly, its build number has been bumped to 2.

- Necessitated by: CMAKE consistency Sweep:
  https://github.com/irods/irods_capability_indexing/commit/1bada02b0492f7f8da699bda9b2e4fbec05307dd

- Using RPATHs, libjsoncpp.so.19 and libcpr.so were being found, but as of the cited commit we've
  employed the --enable-new-dtags link flag (forcing use of RUNPATH versus RPATH) and these libs were no
  longer being found, preventing libelasticlient.so from being loaded by the indexing plugin.

- $ORIGIN became necessary for helping libelasticlient.so to find libjsoncpp.so.19 (in the same lib/
  directory), and the CPR library path also needed to be explicitly added.