### PR TITLE
Ubuntu 20.04 / Python 3 / Version bumps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all : autoconf avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq cpr cpython elasticlient fmt imagemagick json libarchive libs3 mungefs nanodbc pistache qpid qpid-proton qpid-with-proton redis spdlog zeromq4-1
+all : autoconf avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq cpr elasticlient fmt imagemagick json libarchive libs3 mungefs nanodbc pistache qpid qpid-proton qpid-with-proton redis spdlog zeromq4-1
 
 
 server : avro boost catch2 clang-runtime cppzmq fmt json libarchive nanodbc spdlog zeromq4-1
@@ -54,7 +54,7 @@ catch2_clean :
 	@rm -rf catch2*
 	@rm -rf $(CATCH2_PACKAGE)
 
-$(CLANG_PACKAGE) : $(CMAKE_PACKAGE) $(CPYTHON_PACKAGE)
+$(CLANG_PACKAGE) : $(CMAKE_PACKAGE)
 	./build.py $(BUILD_OPTIONS) clang > clang.log 2>&1
 clang : $(CLANG_PACKAGE)
 clang_clean :
@@ -93,14 +93,6 @@ cpr_clean :
 	@echo "Cleaning cpr..."
 	@rm -rf cpr*
 	@rm -rf $(CPR_PACKAGE)
-
-$(CPYTHON_PACKAGE) :
-	./build.py $(BUILD_OPTIONS) cpython > cpython.log 2>&1
-cpython : $(CPYTHON_PACKAGE)
-cpython_clean :
-	@echo "Cleaning cpython..."
-	@rm -rf cpython*
-	@rm -rf $(CPYTHON_PACKAGE)
 
 $(ELASTICLIENT_PACKAGE) : $(CLANG_PACKAGE) $(BOOST_PACKAGE)
 	./build.py $(BUILD_OPTIONS) elasticlient > elasticlient.log 2>&1
@@ -230,7 +222,7 @@ zeromq4-1_clean :
 	@rm -rf zeromq4-1*
 	@rm -rf $(ZEROMQ4-1_PACKAGE)
 
-clean : autoconf_clean avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean cpr_clean cpython_clean elasticlient_clean imagemagick_clean jansson_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean qpid_clean redis_clean spdlog_clean zeromq4-1_clean
+clean : autoconf_clean avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean cpr_clean elasticlient_clean imagemagick_clean jansson_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean qpid_clean redis_clean spdlog_clean zeromq4-1_clean
 	@echo "Cleaning generated files..."
 	@rm -rf packages.mk
 	@echo "Done."

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ In a new container, run the following:
 ```bash
 apt-get update -y && apt-get install -y sudo git python3 python3-distro
 ./install_prerequisites.py
+
+# The following lines apply to Ubuntu 20 only!!!
+update-alternatives --install /usr/local/bin/gcc gcc /usr/bin/gcc-10 1
+update-alternatives --install /usr/local/bin/g++ g++ /usr/bin/g++-10 1
+hash -r
+
 make # or "make server" for packages specific to building the iRODS server.
 ```
 
@@ -49,7 +55,8 @@ make # or "make server" for packages specific to building the iRODS server.
 ## AlmaLinux 8 and Rocky Linux 8
 
 ```bash
-dnf update -y && dnf install -y sudo git python3 python3-distro
+dnf update -y && dnf install -y sudo git python3 python3-distro gcc-toolset-11
 ./install_prerequisites.py
+scl enable gcc-toolset-11 bash
 make # or "make server" for packages specific to building the iRODS server.
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Currently tested on:
 - Ubuntu 14
 - Ubuntu 16
 - Ubuntu 18
+- Ubuntu 20
 - CentOS 7
 - AlmaLinux 8
 - Rocky Linux 8
@@ -19,8 +20,11 @@ The automated scripts run commands as `sudo` and update system libraries and com
 In a new container, you'll probably need the following:
 
 ```
-# Ubuntu 16
+# Ubuntu 16+
 apt-get update -y && apt-get install -y sudo git python
+
+# Ubuntu 20
+apt-get update -y && apt-get install -y sudo git python2
 
 # CentOS 7
 yum update -y && yum install -y sudo git python

--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 Currently tested on:
 
-- Ubuntu 14
-- Ubuntu 16
 - Ubuntu 18
 - Ubuntu 20
 - CentOS 7
 - AlmaLinux 8
 - Rocky Linux 8
-- Debian 9
+- Debian 11
 
 # Assumptions
 
@@ -17,34 +15,41 @@ This repository is expected to build in a VM or container environment that is is
 
 The automated scripts run commands as `sudo` and update system libraries and compilers, etc.
 
-In a new container, you'll probably need the following:
+In a new container, run the following:
 
-```
-# Ubuntu 16+
-apt-get update -y && apt-get install -y sudo git python
+## Ubuntu 18, Ubuntu 20, and Debian 11
 
-# Ubuntu 20
-apt-get update -y && apt-get install -y sudo git python2
-
-# CentOS 7
-yum update -y && yum install -y sudo git python
-
-# AlmaLinux 8 and Rocky Linux 8
-dnf update -y && dnf install -y sudo git python2
-```
-
-# Installation
-
-Before building the software listed in this repository, their own prerequisites must be met.
-
-This is handled as automatically as possible with the `install_prerequisites.py` script.
-
-```
+```bash
+apt-get update -y && apt-get install -y sudo git python3 python3-distro
 ./install_prerequisites.py
-make
+make # or "make server" for packages specific to building the iRODS server.
 ```
 
-To only build the components for the iRODS Server:
+## CentOS 7
+
+```bash
+yum update -y && yum install -y sudo git python3 centos-release-scl
+yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++
+
+# Installing the prerequistes must be done before enabling the GCC compiler
+# environment.
+python3 -m venv build_env
+source build_env/bin/activate
+python -m pip install distro
+./install_prerequisites.py
+
+# Enable the GCC 10 compiler tools.
+scl enable devtoolset-10 bash
+
+# Although it appears that the python virtual environment has been deactivated,
+# trust and believe it is still active.
+make # or "make server" for packages specific to building the iRODS server.
 ```
-make server
+
+## AlmaLinux 8 and Rocky Linux 8
+
+```bash
+dnf update -y && dnf install -y sudo git python3 python3-distro
+./install_prerequisites.py
+make # or "make server" for packages specific to building the iRODS server.
 ```

--- a/build.py
+++ b/build.py
@@ -261,26 +261,16 @@ def build_package(target, build_native_package):
 
     # get
     if target == 'clang':
-        if not os.path.isdir(os.path.join(build_dir,"build")):
-            mkdir_p(os.path.join(build_dir,"build"))
-        target_dirs = [
-                ('llvm', 'llvm'),
-                ('clang', 'llvm/tools/clang'),
-                ('clang-tools-extra', 'llvm/tools/clang/tools/extra'),
-                ('compiler-rt', 'llvm/projects/compiler-rt'),
-                ('libcxx', 'llvm/projects/libcxx'),
-                ('libcxxabi', 'llvm/projects/libcxxabi')
-            ]
-        for t in target_dirs:
-            if not os.path.isdir(os.path.join(build_dir,t[1])):
-                mkdir_p(os.path.dirname(os.path.join(build_dir,t[1])))
-                os.chdir(os.path.dirname(os.path.join(build_dir,t[1])))
-                log.debug('cwd: {0}'.format(os.getcwd()))
-                run_cmd(['git', 'clone', 'https://github.com/irods/{0}'.format(t[0]),t[1].split("/")[-1]])
-            os.chdir(os.path.join(build_dir,t[1]))
-            log.debug('cwd: {0}'.format(os.getcwd()))
-            run_cmd(['git', 'fetch'], check_rc='git fetch failed')
-            run_cmd(['git', 'checkout', v['commitish']], check_rc='git checkout failed')
+        if not os.path.isdir(os.path.join(build_dir, "build")):
+            mkdir_p(os.path.join(build_dir, "build"))
+        os.chdir(build_dir)
+        log.debug('cwd: {0}'.format(os.getcwd()))
+        # Clone only the version we want! It would take too long to download all of LLVM.
+        run_cmd(['git', 'clone', '--depth', '1', '--branch', v['commitish'], 'https://github.com/irods/llvm-project'])
+        os.chdir('llvm-project')
+        log.debug('cwd: {0}'.format(os.getcwd()))
+        run_cmd(['git', 'fetch'], check_rc='git fetch failed')
+        run_cmd(['git', 'checkout', v['commitish']], check_rc='git checkout failed')
     elif target == 'clang-runtime':
         if not os.path.isdir(os.path.join(build_dir,target)):
             mkdir_p(os.path.join(build_dir, target))
@@ -323,7 +313,7 @@ def build_package(target, build_native_package):
 
     # build
     if target == 'clang':
-        os.chdir(os.path.join(build_dir,"build"))
+        os.chdir(os.path.join(build_dir, "llvm-project"))
     else:
         os.chdir(os.path.join(build_dir,target))
 

--- a/build.py
+++ b/build.py
@@ -175,12 +175,6 @@ def build_package(target, build_native_package):
     # prepare executables
     os.chdir(os.path.join(script_path))
     python_executable = sys.executable
-    if target == 'cpython':
-        log.debug('skipping cpython ... current python version {0} >= 2.7'.format(platform.python_version()))
-        # touch file to satisfy make
-        if build_native_package:
-            touch(get_package_filename(target))
-        return
     log.debug('python_executable: [{0}]'.format(python_executable))
     cmake_executable = get_local_path('cmake',['bin','cmake'])
     log.debug('cmake_executable: [{0}]'.format(cmake_executable))
@@ -289,7 +283,7 @@ def build_package(target, build_native_package):
         set_clang_path()
 
     myenv = os.environ.copy()
-    if target not in ['clang','cmake','autoconf','cpython']:
+    if target not in ['clang','cmake','autoconf']:
         clang_bindir = get_local_path('clang',['bin'])
         myenv['CC'] = '{0}/clang'.format(clang_bindir)
         log.debug('CC='+myenv['CC'])

--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -73,11 +73,21 @@ def main():
         build.run_cmd(cmd, check_rc='getting updates failed')
         # get prerequisites
         cmd = ['sudo','DEBIAN_FRONTEND=noninteractive','apt-get','install','-y','curl','automake','make',
-               'autoconf2.13','texinfo','help2man','g++','git','gpg','lsb-release','libtool','libbz2-dev',
+               'autoconf2.13','texinfo','help2man','git','gpg','lsb-release','libtool','libbz2-dev',
                'zlib1g-dev','libcurl4-gnutls-dev','libxml2-dev','pkg-config','python3-dev','uuid-dev',
                'libssl-dev','fuse','libfuse2','libfuse-dev', 'libmicrohttpd-dev', 'unixodbc-dev']
         if distro_id in ['debian']:
-            cmd.append('procps') # Debian containers do not have "ps" command by default.
+            # Debian 11's default GCC is version 10.2.
+            # Debian containers do not have "ps" command by default.
+            cmd.extend(['g++', 'procps']) 
+        # At this point, we know we're dealing with some version of Ubuntu.
+        elif distro_major_version == '20':
+            # Compiling LLVM 13's libcxx requires at least GCC 10.
+            cmd.extend(['gcc-10', 'g++-10']) 
+        else:
+            # Ubuntu 18 does not have any issues compiling LLVM 13's libcxx
+            # because it is using GCC 7 which does not support any C++20 features.
+            cmd.append('g++')
         build.run_cmd(cmd, check_rc='installing prerequisites failed')
         cmd = ['sudo','apt-get','install','-y','autoconf','rsync']
         build.run_cmd(cmd, check_rc='installing autoconf failed')

--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -75,9 +75,14 @@ def main():
         build.run_cmd(cmd, check_rc='getting updates failed')
         # get prerequisites
         cmd = ['sudo','apt-get','install','-y','curl','automake','make','autoconf2.13','texinfo',
-               'help2man','g++','git','lsb-release','libtool','python-dev','libbz2-dev','zlib1g-dev',
+               'help2man','g++','git','lsb-release','libtool','libbz2-dev','zlib1g-dev',
                'libcurl4-gnutls-dev','libxml2-dev','pkg-config','uuid-dev','libssl-dev', 'fuse', 'libfuse2',
                'libfuse-dev', 'libmicrohttpd-dev', 'unixodbc-dev']
+        if pld in ['Ubuntu'] and platform.linux_distribution()[1] < '20':
+            cmd.append('python-dev')
+        else:
+            cmd.insert(1, 'DEBIAN_FRONTEND=noninteractive') # Avoids hanging on tzdata configuration.
+            cmd.extend(['python2-dev', 'gpg'])
         build.run_cmd(cmd, check_rc='installing prerequisites failed')
         # if old, bootstrap g++
         if pld in ['Ubuntu'] and platform.linux_distribution()[1] < '14':

--- a/versions.json
+++ b/versions.json
@@ -83,13 +83,13 @@
         "fpm_directories": ["include"]
     },
     "clang": {
-        "commitish": "llvmorg-11.1.0",
-        "version_string": "11.1.0",
+        "commitish": "llvmorg-13.0.0",
+        "version_string": "13.0.0",
         "license": "LLVM",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
-            "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE=TEMPLATE_PYTHON_EXECUTABLE -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;' ../llvm-project/llvm",
+            "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE=TEMPLATE_PYTHON_EXECUTABLE -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;' ../llvm-project/llvm",
             "make -jTEMPLATE_JOBS",
             "make -jTEMPLATE_JOBS check-clang-tools",
             "make -jTEMPLATE_JOBS install",

--- a/versions.json
+++ b/versions.json
@@ -18,15 +18,15 @@
         "fpm_directories": ["bin","share"]
     },
     "avro": {
-        "commitish": "release-1.9.0",
-        "version_string": "1.9.0",
+        "commitish": "release-1.11.0",
+        "version_string": "1.11.0",
         "license": "Apache License 2.0",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p lang/c++/build",
             "cd lang/c++/build; rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_INSTALL_RPATH=/TEMPLATE_BOOST_RPATH\\;/TEMPLATE_CLANG_RUNTIME_RPATH -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DBOOST_ROOT=TEMPLATE_BOOST_ROOT -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' ..",
-            "cd lang/c++/build; env LD_LIBRARY_PATH=TEMPLATE_CLANG_CPP_LIBRARIES make -jTEMPLATE_JOBS; make install"
+            "cd lang/c++/build; env LD_LIBRARY_PATH='TEMPLATE_CLANG_CPP_LIBRARIES:/TEMPLATE_CLANG_RUNTIME_RPATH:/TEMPLATE_BOOST_ROOT/lib' make -jTEMPLATE_JOBS; make install"
             ],
         "external_build_steps": [
             "cd lang/c++/build",
@@ -51,8 +51,8 @@
         "fpm_directories": ["include","lib","lib64"]
     },
     "boost": {
-        "commitish": "boost-1.67.0",
-        "version_string": "1.67.0",
+        "commitish": "boost-1.77.0",
+        "version_string": "1.77.0",
         "license": "Boost Software License 1.0",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
@@ -68,8 +68,8 @@
         "fpm_directories": ["include","lib"]
     },
     "catch2": {
-        "commitish": "v2.3.0",
-        "version_string": "2.3.0",
+        "commitish": "v2.13.7",
+        "version_string": "2.13.7",
         "license": "Boost Software License 1.0",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
@@ -83,19 +83,19 @@
         "fpm_directories": ["include"]
     },
     "clang": {
-        "commitish": "release_60",
-        "version_string": "6.0",
+        "commitish": "llvmorg-11.1.0",
+        "version_string": "11.1.0",
         "license": "LLVM",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
-            "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE:FILEPATH=TEMPLATE_PYTHON_EXECUTABLE ../llvm",
+            "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE:FILEPATH=TEMPLATE_PYTHON_EXECUTABLE -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;' ../llvm-project/llvm",
             "make -jTEMPLATE_JOBS",
             "make -jTEMPLATE_JOBS check-clang-tools",
             "make -jTEMPLATE_JOBS install",
             "cp ./libexec/c++-analyzer TEMPLATE_INSTALL_PREFIX/bin",
             "cp ./libexec/ccc-analyzer TEMPLATE_INSTALL_PREFIX/bin"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -103,7 +103,7 @@
     },
     "clang-runtime": {
         "commitish": "not-used-same-as-clang",
-        "version_string": "6.0",
+        "version_string": "11.1.0",
         "license": "LLVM",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
@@ -136,8 +136,8 @@
         "fpm_directories": ["bin","doc","share"]
     },
     "cppzmq": {
-        "commitish": "v4.2.3",
-        "version_string": "4.2.3",
+        "commitish": "v4.8.1",
+        "version_string": "4.8.1",
         "license": "LGPL v3",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
@@ -206,10 +206,10 @@
         "fpm_directories": ["include","lib"]
     },
     "fmt": {
-        "commitish": "6.1.2",
-        "version_string": "6.1.2",
+        "commitish": "8.0.1",
+        "version_string": "8.0.1",
         "license": "MIT",
-        "consortium_build_number": "1",
+        "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -271,10 +271,10 @@
         "fpm_directories": ["include","lib"]
     },
     "libarchive": {
-        "commitish": "v3.3.2",
-        "version_string": "3.3.2",
+        "commitish": "v3.5.2",
+        "version_string": "3.5.2",
         "license": "BSD 2-Clause",
-        "consortium_build_number": "1",
+        "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "TEMPLATE_CMAKE_EXECUTABLE -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_C_FLAGS:STRING=-fPIC -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX .",
@@ -424,10 +424,10 @@
         "fpm_directories": ["bin"]
     },
     "spdlog": {
-        "commitish": "v1.5.0",
-        "version_string": "1.5.0",
+        "commitish": "v1.9.2",
+        "version_string": "1.9.2",
         "license": "MIT",
-        "consortium_build_number": "1",
+        "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
@@ -439,8 +439,8 @@
         "fpm_directories": ["include"]
     },
     "zeromq4-1": {
-        "commitish": "v4.1.6",
-        "version_string": "4.1.6",
+        "commitish": "v4.1.8",
+        "version_string": "4.1.8",
         "license": "LGPL v3",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",

--- a/versions.json
+++ b/versions.json
@@ -11,7 +11,7 @@
             "./configure --prefix=TEMPLATE_INSTALL_PREFIX",
             "make -jTEMPLATE_JOBS",
             "make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -27,7 +27,7 @@
             "mkdir -p lang/c++/build",
             "cd lang/c++/build; rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_INSTALL_RPATH=/TEMPLATE_BOOST_RPATH\\;/TEMPLATE_CLANG_RUNTIME_RPATH -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DBOOST_ROOT=TEMPLATE_BOOST_ROOT -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' ..",
             "cd lang/c++/build; env LD_LIBRARY_PATH='TEMPLATE_CLANG_CPP_LIBRARIES:/TEMPLATE_CLANG_RUNTIME_RPATH:/TEMPLATE_BOOST_ROOT/lib' make -jTEMPLATE_JOBS; make install"
-            ],
+        ],
         "external_build_steps": [
             "cd lang/c++/build",
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
@@ -44,7 +44,7 @@
             "mkdir -p build",
             "cd build; TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_SHARED_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_INCLUDE_DIRECTORIES_BEFORE=ON -DCMAKE_CXX_FLAGS='-ITEMPLATE_CLANG_CPP_HEADERS -nostdinc++' -DBUILD_ONLY='s3;sts' ..",
             "cd build; make -jTEMPLATE_JOBS; make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -58,10 +58,10 @@
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "git submodule update --init",
-            "./bootstrap.sh --prefix=TEMPLATE_INSTALL_PREFIX",
+            "./bootstrap.sh --prefix=TEMPLATE_INSTALL_PREFIX --with-python=/usr/bin/python3",
             "./b2 headers",
             "./b2 install toolset=clang --without-mpi threading=multi link=shared cxxflags='-fPIC -DBOOST_SYSTEM_NO_DEPRECATED -stdlib=libc++ -std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' linkflags='-stdlib=libc++ -Wl,-rpath,/TEMPLATE_CLANG_RUNTIME_RPATH:/TEMPLATE_BOOST_RPATH' -jTEMPLATE_JOBS"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -76,7 +76,7 @@
         "build_steps": [
             "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
             "cp single_include/catch2/catch.hpp TEMPLATE_INSTALL_PREFIX/include"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -89,7 +89,7 @@
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
-            "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE:FILEPATH=TEMPLATE_PYTHON_EXECUTABLE -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;' ../llvm-project/llvm",
+            "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE=TEMPLATE_PYTHON_EXECUTABLE -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;' ../llvm-project/llvm",
             "make -jTEMPLATE_JOBS",
             "make -jTEMPLATE_JOBS check-clang-tools",
             "make -jTEMPLATE_JOBS install",
@@ -129,7 +129,7 @@
             "./configure --prefix=TEMPLATE_INSTALL_PREFIX --parallel=TEMPLATE_JOBS",
             "make -jTEMPLATE_JOBS",
             "make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -144,7 +144,7 @@
         "build_steps": [
             "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
             "cp zmq.hpp TEMPLATE_INSTALL_PREFIX/include"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -160,7 +160,7 @@
             "git submodule update --init",
             "rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DBUILD_SHARED_LIBS=True -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_INSTALL_RPATH=/TEMPLATE_CPR_RPATH\\;/TEMPLATE_BOOST_RPATH\\;/TEMPLATE_CLANG_RUNTIME_RPATH -DCMAKE_BUILD_WITH_INSTALL_RPATH=True -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DBOOST_ROOT=TEMPLATE_BOOST_ROOT -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' .",
             "make -jTEMPLATE_JOBS"
-            ],
+        ],
         "external_build_steps": [
             "ls -l ",
             "mkdir -p TEMPLATE_INSTALL_PREFIX",
@@ -180,7 +180,7 @@
             "./configure --prefix=TEMPLATE_INSTALL_PREFIX",
             "make -jTEMPLATE_JOBS",
             "make altinstall"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -199,7 +199,7 @@
             "cd build && make",
             "cd build && cp external/httpmockserver/libhttpmockserver.pc ./",
             "cd build && make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -215,7 +215,7 @@
             "mkdir -p build",
             "cd build; rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G'Unix Makefiles' -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_SHARED_LIBS=TRUE -DFMT_TEST=OFF -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' ..",
             "cd build; make fmt install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -231,7 +231,7 @@
             "./configure --prefix=TEMPLATE_INSTALL_PREFIX --exec-prefix=TEMPLATE_INSTALL_PREFIX --libdir=TEMPLATE_INSTALL_PREFIX/lib",
             "make -jTEMPLATE_JOBS",
             "make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -248,7 +248,7 @@
             "./configure --prefix=TEMPLATE_INSTALL_PREFIX --libdir=TEMPLATE_INSTALL_PREFIX/lib --with-pic",
             "make -jTEMPLATE_JOBS",
             "make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -264,7 +264,7 @@
             "mkdir -p build",
             "cd build; TEMPLATE_CMAKE_EXECUTABLE .. -G'Unix Makefiles' -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DJSON_MultipleHeaders=ON",
             "cd build; make -jTEMPLATE_JOBS; make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -280,7 +280,7 @@
             "TEMPLATE_CMAKE_EXECUTABLE -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_C_FLAGS:STRING=-fPIC -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX .",
             "make -jTEMPLATE_JOBS",
             "make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -299,7 +299,7 @@
             "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
             "mkdir -p TEMPLATE_INSTALL_PREFIX/lib",
             "make DESTDIR=TEMPLATE_INSTALL_PREFIX TEMPLATE_LIBS3_MAKEFILE_STRING install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -315,7 +315,7 @@
             "mkdir -p build",
             "cd build; rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCPPZMQ_PATH=TEMPLATE_CPPZMQ_PATH -DZMQ_PATH=TEMPLATE_ZMQ_PATH -DAVRO_PATH=TEMPLATE_AVRO_PATH -DCLANG_LIBS=TEMPLATE_CLANG_CPP_LIBRARIES -DBOOST_PATH=TEMPLATE_BOOST_ROOT -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DIRODS_EXTERNALS_PACKAGE_ROOT=TEMPLATE_SCRIPT_PATH -DCMAKE_INSTALL_RPATH=/TEMPLATE_BOOST_RPATH\\;/TEMPLATE_AVRO_RPATH\\;/TEMPLATE_ZMQ_RPATH\\;/TEMPLATE_LIBARCHIVE_RPATH\\;/TEMPLATE_CLANG_RUNTIME_RPATH ..",
             "cd build; env LD_LIBRARY_PATH=TEMPLATE_CLANG_CPP_LIBRARIES make -jTEMPLATE_JOBS; make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -331,7 +331,7 @@
             "mkdir -p build",
             "cd build; rm -f CMakeCache.txt;TEMPLATE_CMAKE_EXECUTABLE -G'Unix Makefiles' -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DBUILD_SHARED_LIBS=ON -DNANODBC_DISABLE_EXAMPLES=ON -DNANODBC_DISABLE_TESTS=ON -DNANODBC_ODBC_VERSION=SQL_OV_ODBC3 -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_CXX_FLAGS='-std=c++14 -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' ..",
             "cd build; make nanodbc install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -350,7 +350,7 @@
             "mkdir -p build",
             "cd build; rm -f CMakeCache.txt; TEMPLATE_CMAKE_EXECUTABLE -G'Unix Makefiles' -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS -Wno-sign-conversion' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_BUILD_WITH_INSTALL_RPATH=True -DCMAKE_INSTALL_RPATH=/TEMPLATE_CLANG_RUNTIME_RPATH ..",
             "cd build; make -jTEMPLATE_JOBS install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -367,7 +367,7 @@
             "mkdir -p build",
             "cd build; env LD_LIBRARY_PATH=TEMPLATE_CLANG_CPP_LIBRARIES TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DPKG_CONFIG_PATH=TEMPLATE_QPID-PROTON_INSTALL_PATH -DCMAKE_INSTALL_RPATH=/TEMPLATE_QPID_RPATH\\;/TEMPLATE_BOOST_RPATH\\;/TEMPLATE_CLANG_RUNTIME_RPATH -DCMAKE_BUILD_WITH_INSTALL_RPATH=True -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DLIB_SUFFIX:STRING='' -DBOOST_ROOT=TEMPLATE_BOOST_ROOT -DBUILD_PROBES=no -DBUILD_BINDING_PERL=no -DBUILD_BINDING_RUBY=no -DBUILD_BINDING_PYTHON=no -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi -lpthread' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' ../qpid/cpp",
             "cd build; make -jTEMPLATE_JOBS; make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -383,7 +383,7 @@
             "mkdir -p build",
             "cd build; TEMPLATE_CMAKE_EXECUTABLE .. -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_CXX_FLAGS='-nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_SHARED_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DBUILD_JAVA=OFF -DBUILD_RUBY=OFF -DBUILD_PYTHON=OFF -DSYSINSTALL_BINDINGS=OFF",
             "cd build; make -jTEMPLATE_JOBS; make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -417,7 +417,7 @@
         "build_steps": [
             "make -jTEMPLATE_JOBS",
             "make install PREFIX=TEMPLATE_INSTALL_PREFIX"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -432,7 +432,7 @@
         "build_steps": [
             "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
             "cp -r include/spdlog TEMPLATE_INSTALL_PREFIX/include"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
@@ -448,7 +448,7 @@
             "mkdir -p build",
             "cd build; env LD_LIBRARY_PATH=TEMPLATE_CLANG_CPP_LIBRARIES TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_INSTALL_RPATH=/TEMPLATE_CLANG_RUNTIME_RPATH ..",
             "cd build; make -jTEMPLATE_JOBS; make install"
-            ],
+        ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],

--- a/versions.json
+++ b/versions.json
@@ -170,22 +170,6 @@
         ],
         "fpm_directories": ["include","lib"]
     },
-    "cpython": {
-        "commitish": "2.7",
-        "version_string": "2.7",
-        "license": "PSF v2",
-        "consortium_build_number": "0",
-        "externals_root": "opt/irods-externals",
-        "build_steps": [
-            "./configure --prefix=TEMPLATE_INSTALL_PREFIX",
-            "make -jTEMPLATE_JOBS",
-            "make altinstall"
-        ],
-        "external_build_steps": [
-            "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
-        ],
-        "fpm_directories": ["bin","include","lib","share"]
-    },
     "elasticlient" : {
         "commitish": "3adb172a26baae1a995e810e49fee1688ea44df5",
         "version_string": "0.1.0",


### PR DESCRIPTION
This PR adds support for building only the externals packages needed for compiling the iRODS server.

This PR needs to be tested to make sure CentOS 7, AlmaLinux 8, and Rocky Linux 8 support is still functional. 