### PR TITLE
[irods/irods#5669] Bump CMake to 3.21.4

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -120,13 +120,13 @@
         "fpm_directories": ["lib"]
     },
     "cmake": {
-        "commitish": "v3.11.4",
-        "version_string": "3.11.4",
+        "commitish": "v3.21.4",
+        "version_string": "3.21.4",
         "license": "BSD 3-Clause",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
-            "./configure --prefix=TEMPLATE_INSTALL_PREFIX",
+            "./configure --prefix=TEMPLATE_INSTALL_PREFIX --parallel=TEMPLATE_JOBS",
             "make -jTEMPLATE_JOBS",
             "make install"
             ],


### PR DESCRIPTION
Additionally, pass --parallel to configure.

This will require that https://github.com/irods/CMake pull new tags from upstream

I haven't yet tested that this works on anything beyond my personal rig, due to our fork not having the `v3.21.4` tag.