### PR TITLE
[141, 142, 143, 144, irods/irods_5669, irods/irods_6086] Build spdlog, catch2, and cppzmq with cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ redis_clean :
 	@rm -rf redis*
 	@rm -rf $(REDIS_PACKAGE)
 
-$(SPDLOG_PACKAGE) :
+$(SPDLOG_PACKAGE) : $(CMAKE_PACKAGE)
 	./build.py $(BUILD_OPTIONS) spdlog > spdlog.log 2>&1
 spdlog : $(SPDLOG_PACKAGE)
 spdlog_clean :

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ boost_clean :
 	@rm -rf boost*
 	@rm -rf $(BOOST_PACKAGE)
 
-$(CATCH2_PACKAGE) :
+$(CATCH2_PACKAGE) : $(CMAKE_PACKAGE)
 	./build.py $(BUILD_OPTIONS) catch2 > catch2.log 2>&1
 catch2 : $(CATCH2_PACKAGE)
 catch2_clean :

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ redis_clean :
 	@rm -rf redis*
 	@rm -rf $(REDIS_PACKAGE)
 
-$(SPDLOG_PACKAGE) : $(CMAKE_PACKAGE)
+$(SPDLOG_PACKAGE) : $(FMT_PACKAGE)
 	./build.py $(BUILD_OPTIONS) spdlog > spdlog.log 2>&1
 spdlog : $(SPDLOG_PACKAGE)
 spdlog_clean :

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ cmake_clean :
 	@rm -rf cmake*
 	@rm -rf $(CMAKE_PACKAGE)
 
-$(CPPZMQ_PACKAGE) :
+$(CPPZMQ_PACKAGE) : $(ZEROMQ4-1_PACKAGE)
 	./build.py $(BUILD_OPTIONS) cppzmq > cppzmq.log 2>&1
 cppzmq : $(CPPZMQ_PACKAGE)
 cppzmq_clean :

--- a/build.py
+++ b/build.py
@@ -188,6 +188,8 @@ def build_package(target, build_native_package):
     log.debug('avro_root: [{0}]'.format(avro_root))
     boost_root = get_local_path('boost',[])
     log.debug('boost_root: [{0}]'.format(boost_root))
+    fmt_root = get_local_path('fmt',[])
+    log.debug('fmt_root: [{0}]'.format(fmt_root))
 
     # prepare other strings
     if get_package_type() == 'osxpkg':
@@ -330,6 +332,7 @@ def build_package(target, build_native_package):
         i = re.sub("TEMPLATE_ZMQ_RPATH", zmq_rpath, i)
         i = re.sub("TEMPLATE_ZMQ_PATH", zmq_root, i)
         i = re.sub("TEMPLATE_CPPZMQ_PATH", cppzmq_root, i)
+        i = re.sub("TEMPLATE_FMT_PATH", fmt_root, i)
         run_cmd(i, run_env=myenv, unsafe_shell=True, check_rc='build failed')
 
     # MacOSX - after building boost

--- a/versions.json
+++ b/versions.json
@@ -414,13 +414,14 @@
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
-            "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
-            "cp -r include/spdlog TEMPLATE_INSTALL_PREFIX/include"
+            "mkdir -p build",
+            "cd build; TEMPLATE_CMAKE_EXECUTABLE .. -G'Unix Makefiles' -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DSPDLOG_BUILD_BENCH=OFF -DSPDLOG_BUILD_EXAMPLE=OFF",
+            "cd build; make -jTEMPLATE_JOBS; make install"
         ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include"]
+        "fpm_directories": ["include","lib"]
     },
     "zeromq4-1": {
         "commitish": "v4.1.8",

--- a/versions.json
+++ b/versions.json
@@ -71,16 +71,17 @@
         "commitish": "v2.13.7",
         "version_string": "2.13.7",
         "license": "Boost Software License 1.0",
-        "consortium_build_number": "0",
+        "consortium_build_number": "1",
         "externals_root": "opt/irods-externals",
         "build_steps": [
-            "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
-            "cp single_include/catch2/catch.hpp TEMPLATE_INSTALL_PREFIX/include"
+            "mkdir -p build",
+            "cd build; TEMPLATE_CMAKE_EXECUTABLE .. -G'Unix Makefiles' -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DCATCH_USE_VALGRIND=OFF -DCATCH_BUILD_EXAMPLES=OFF -DCATCH_ENABLE_COVERAGE=OFF -DCATCH_ENABLE_WERROR=OFF -DCATCH_BUILD_TESTING=OFF -DBUILD_TESTING=OFF",
+            "cd build; make -jTEMPLATE_JOBS; make install"
         ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include"]
+        "fpm_directories": ["include","lib","share"]
     },
     "clang": {
         "commitish": "llvmorg-13.0.0",

--- a/versions.json
+++ b/versions.json
@@ -411,11 +411,11 @@
         "commitish": "v1.9.2",
         "version_string": "1.9.2",
         "license": "MIT",
-        "consortium_build_number": "0",
+        "consortium_build_number": "1",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
-            "cd build; TEMPLATE_CMAKE_EXECUTABLE .. -G'Unix Makefiles' -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DSPDLOG_BUILD_BENCH=OFF -DSPDLOG_BUILD_EXAMPLE=OFF",
+            "cd build; TEMPLATE_CMAKE_EXECUTABLE .. -G'Unix Makefiles' -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -Dfmt_DIR=TEMPLATE_FMT_PATH/lib/cmake/fmt -DSPDLOG_FMT_EXTERNAL=ON -DSPDLOG_BUILD_BENCH=OFF -DSPDLOG_BUILD_EXAMPLE=OFF",
             "cd build; make -jTEMPLATE_JOBS; make install"
         ],
         "external_build_steps": [

--- a/versions.json
+++ b/versions.json
@@ -140,16 +140,17 @@
         "commitish": "v4.8.1",
         "version_string": "4.8.1",
         "license": "LGPL v3",
-        "consortium_build_number": "0",
+        "consortium_build_number": "1",
         "externals_root": "opt/irods-externals",
         "build_steps": [
-            "mkdir -p TEMPLATE_INSTALL_PREFIX/include",
-            "cp zmq.hpp TEMPLATE_INSTALL_PREFIX/include"
+            "mkdir -p build",
+            "cd build; TEMPLATE_CMAKE_EXECUTABLE .. -G'Unix Makefiles' -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_LIBDIR=lib -DZeroMQ_INCLUDE_DIR=TEMPLATE_ZMQ_PATH/include -DZeroMQ_INCLUDE_DIR=TEMPLATE_ZMQ_PATH/include -DZeroMQ_LIBRARY=TEMPLATE_ZMQ_PATH/lib/libzmq.so -Dpkgcfg_lib_PC_LIBZMQ_zmq=TEMPLATE_ZMQ_PATH/lib/libzmq.so -DCPPZMQ_BUILD_TESTS=OFF -DCPPZMQ_CMAKECONFIG_INSTALL_DIR=lib/cmake/cppzmq",
+            "cd build; make -jTEMPLATE_JOBS; make install"
         ],
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include"]
+        "fpm_directories": ["include","lib"]
     },
     "cpr": {
         "commitish": "1.3.0",


### PR DESCRIPTION
This PR accomplishes a few things:
- Puts CMake configuration files in the spdlog, catch2, and cppzmq packages
- Puts catch2's headers in the right place
- Removes the extra copy of fmt from spdlog