### PR TITLE
[146, irods/irods_5669] Pull upstream patches into boost build

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -54,10 +54,13 @@
         "commitish": "boost-1.77.0",
         "version_string": "1.77.0",
         "license": "Boost Software License 1.0",
-        "consortium_build_number": "0",
+        "consortium_build_number": "1",
         "externals_root": "opt/irods-externals",
+        "_comment": "The git cherry-picks are backports from 1.78 and can be removed once we advance to 1.78+",
         "build_steps": [
             "git submodule update --init",
+            "cd tools/boost_install; git cherry-pick 4009ed07e7da3fc4236b736a4860a7d3d1a6d330",
+            "cd tools/boost_install; git cherry-pick e193f080c7d209516ac9b712fa0c50bb08026fa2",
             "./bootstrap.sh --prefix=TEMPLATE_INSTALL_PREFIX --with-python=/usr/bin/python3",
             "./b2 headers",
             "./b2 install toolset=clang --without-mpi threading=multi link=shared cxxflags='-fPIC -DBOOST_SYSTEM_NO_DEPRECATED -stdlib=libc++ -std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' linkflags='-stdlib=libc++ -Wl,-rpath,/TEMPLATE_CLANG_RUNTIME_RPATH:/TEMPLATE_BOOST_RPATH' -jTEMPLATE_JOBS"


### PR DESCRIPTION
Patches pulled:
- boostorg/boost_install#52 - set `CMP0057` in cmake config
- boostorg/boost_install#53 - fix Python 3.10+ compatibility