### PR TITLE
[#177] Add support for building on Ubuntu 22.04 (main)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ zeromq4-1_clean :
 	@rm -rf zeromq4-1*
 	@rm -rf $(ZEROMQ4-1_PACKAGE)
 
-clean : avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean cpr_clean elasticlient_clean fmt_clean imagemagick_clean jansson_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean redis_clean spdlog_clean zeromq4-1_clean
+clean : avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean cpr_clean elasticlient_clean fmt_clean imagemagick_clean jansson_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean qpid-proton_clean redis_clean spdlog_clean zeromq4-1_clean
 	@echo "Cleaning generated files..."
 	@rm -rf packages.mk
 	@echo "Done."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all : autoconf avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq cpr elasticlient fmt imagemagick json libarchive libs3 mungefs nanodbc pistache qpid-proton redis spdlog zeromq4-1
+all : avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq cpr elasticlient fmt imagemagick json libarchive libs3 mungefs nanodbc pistache qpid-proton redis spdlog zeromq4-1
 
 
 server : avro boost catch2 clang-runtime cppzmq fmt json libarchive nanodbc spdlog zeromq4-1
@@ -13,14 +13,6 @@ packages.mk : Makefile versions.json build.py
 -include packages.mk
 
 $(all) : packages.mk
-
-$(AUTOCONF_PACKAGE) :
-	./build.py $(BUILD_OPTIONS) autoconf > autoconf.log 2>&1
-autoconf : $(AUTOCONF_PACKAGE)
-autoconf_clean :
-	@echo "Cleaning autoconf..."
-	@rm -rf autoconf*
-	@rm -rf $(AUTOCONF_PACKAGE)
 
 $(AVRO_PACKAGE) : $(BOOST_PACKAGE) $(CMAKE_PACKAGE) $(CLANG_PACKAGE)
 	./build.py $(BUILD_OPTIONS) avro > avro.log 2>&1
@@ -206,7 +198,7 @@ zeromq4-1_clean :
 	@rm -rf zeromq4-1*
 	@rm -rf $(ZEROMQ4-1_PACKAGE)
 
-clean : autoconf_clean avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean cpr_clean elasticlient_clean fmt_clean imagemagick_clean jansson_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean redis_clean spdlog_clean zeromq4-1_clean
+clean : avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean cpr_clean elasticlient_clean fmt_clean imagemagick_clean jansson_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean redis_clean spdlog_clean zeromq4-1_clean
 	@echo "Cleaning generated files..."
 	@rm -rf packages.mk
 	@echo "Done."

--- a/build.py
+++ b/build.py
@@ -17,7 +17,7 @@ import sys
 script_path = os.path.dirname(os.path.realpath(__file__))
 
 ruby_requirements = {
-    'ruby': '2.6.5',
+    'ruby': '3.1.2',
     'path': '/usr/local/rvm/bin'
 }
 

--- a/build.py
+++ b/build.py
@@ -287,16 +287,13 @@ def build_package(target, build_native_package):
         set_clang_path()
 
     myenv = os.environ.copy()
-    if target not in ['clang','cmake','autoconf']:
+    if target not in ['clang','cmake']:
         clang_bindir = get_local_path('clang',['bin'])
         myenv['CC'] = '{0}/clang'.format(clang_bindir)
         log.debug('CC='+myenv['CC'])
         myenv['CXX'] = '{0}/clang++'.format(clang_bindir)
         log.debug('CXX='+myenv['CXX'])
         myenv['PATH'] = '{0}:{1}'.format(clang_bindir, myenv['PATH'])
-        log.debug('PATH='+myenv['PATH'])
-        autoconf_bindir = get_local_path('autoconf',['bin'])
-        myenv['PATH'] = '{0}:{1}'.format(autoconf_bindir, myenv['PATH'])
         log.debug('PATH='+myenv['PATH'])
     if get_package_type() == 'osxpkg' and target in ['jansson','zeromq4-1']:
         myenv['LIBTOOLIZE'] = 'glibtoolize'

--- a/versions.json
+++ b/versions.json
@@ -17,10 +17,10 @@
         "fpm_directories": ["bin","include","lib"]
     },
     "aws-sdk-cpp": {
-        "commitish": "1.9.185",
-        "version_string": "1.9.185",
+        "commitish": "1.9.323",
+        "version_string": "1.9.323",
         "license": "Apache License 2.0",
-        "consortium_build_number": "1",
+        "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -260,8 +260,8 @@
     },
     "libs3": {
         "enable_sha": true,
-        "commitish": "d24477a9eb8a2a57fd5ccce5bc74cff468004152",
-        "version_string": "d24477a9",
+        "commitish": "00d2dbe355b78b507f890458b3d656f162384799",
+        "version_string": "00d2dbe3",
         "license": "LGPL v3",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",
@@ -336,7 +336,7 @@
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
-            "cd build; TEMPLATE_CMAKE_EXECUTABLE -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_CXX_FLAGS='-nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_SHARED_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_BUILD_WITH_INSTALL_RPATH=True -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_RPATH=/TEMPLATE_CLANG_RUNTIME_RPATH\\;/TEMPLATE_QPID_PROTON_RPATH -DBUILD_JAVA=OFF -DBUILD_RUBY=OFF -DBUILD_PYTHON=OFF -DSYSINSTALL_BINDINGS=OFF -DENABLE_JSONCPP=OFF -DENABLE_LINKTIME_OPTIMIZATION=NO -DLIB_SUFFIX='' ..",
+            "cd build; TEMPLATE_CMAKE_EXECUTABLE -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DENABLE_WARNING_ERROR=OFF -DCMAKE_CXX_FLAGS='-nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS' -DCMAKE_SHARED_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_EXE_LINKER_FLAGS='-LTEMPLATE_CLANG_CPP_LIBRARIES -stdlib=libc++' -DCMAKE_BUILD_WITH_INSTALL_RPATH=True -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_INSTALL_RPATH=/TEMPLATE_CLANG_RUNTIME_RPATH\\;/TEMPLATE_QPID_PROTON_RPATH -DBUILD_JAVA=OFF -DBUILD_RUBY=OFF -DBUILD_PYTHON=OFF -DSYSINSTALL_BINDINGS=OFF -DENABLE_JSONCPP=OFF -DENABLE_LINKTIME_OPTIMIZATION=NO -DLIB_SUFFIX='' ..",
             "cd build; make -jTEMPLATE_JOBS; make install"
         ],
         "external_build_steps": [

--- a/versions.json
+++ b/versions.json
@@ -1,23 +1,4 @@
 {
-    "autoconf": {
-        "enable_sha": true,
-        "commitish": "5ad3567c",
-        "version_string": "5ad3567c",
-        "license": "GPL v2",
-        "consortium_build_number": "0",
-        "externals_root": "opt/irods-externals",
-        "comment": "ubuntu couldn't build 2.69 due to 8c8522f1 fix coming since",
-        "build_steps": [
-            "autoreconf -vi",
-            "./configure --prefix=TEMPLATE_INSTALL_PREFIX",
-            "make -jTEMPLATE_JOBS",
-            "make install"
-        ],
-        "external_build_steps": [
-            "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
-        ],
-        "fpm_directories": ["bin","share"]
-    },
     "avro": {
         "commitish": "release-1.11.0",
         "version_string": "1.11.0",


### PR DESCRIPTION
\- Remove autoconf external as it is no longer used.

\- Bump required ruby version to 3.1.2 because there is no package for
the previous version available for Ubuntu 22.04 so we need to bump this
version in order to build externals for this platform.

\- Bump SHAs for the following externals in order to prevent build errors
caused by deprecation warnings due to using old OpenSSL types and
functionality:

  aws-sdk-cpp
  libs3
  qpid-proton

Ubuntu 22.04 uses OpenSSL 3.0 and the build processes for these
externals are compatible with 1.1.0.

---

Still trying on other platforms and messing with minimum bumps and whatnot, but this worked for building externals which can build iRODS packages which run in the testing environment.

Sibling PRs:
https://github.com/irods/aws-sdk-cpp/pull/1
https://github.com/irods/libs3/pull/22
https://github.com/irods/qpid-proton/pull/2