### PR TITLE
[irods/irods_resource_plugin_s3#2092] Bump libs3 (4-2-stable)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -304,7 +304,7 @@
     },
     "libs3": {
         "commitish": "c0e278d280cde08fb588d82dcb125198852f2bc9",
-        "version_string": "c0e278d28",
+        "version_string": "c0e278d2",
         "license": "LGPL v3",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",

--- a/versions.json
+++ b/versions.json
@@ -303,8 +303,8 @@
         "rpm_dependencies": ["xz-libs >= 5.2.2"]
     },
     "libs3": {
-        "commitish": "e4197a5e02f03059c48ecac9ed240c66d55e15f6",
-        "version_string": "e4197a5e",
+        "commitish": "c0e278d280cde08fb588d82dcb125198852f2bc9",
+        "version_string": "c0e278d28",
         "license": "LGPL v3",
         "consortium_build_number": "0",
         "externals_root": "opt/irods-externals",


### PR DESCRIPTION
Addresses irods/irods_resource_plugin_s3#2092

Cherry-picked from https://github.com/irods/externals/pull/180

libs3 needs to be bumped to the latest commit on the master branch in order for the main branch to build for the iRODS S3 resource plugin.