### PR TITLE
[#200] Remove imagemagick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all : avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq fmt imagemagick json libarchive libs3 mungefs nanodbc pistache qpid-proton redis spdlog zeromq4-1
+all : avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq fmt json libarchive libs3 mungefs nanodbc pistache qpid-proton redis spdlog zeromq4-1
 
 
 server : avro boost catch2 clang-runtime cppzmq fmt json libarchive nanodbc spdlog zeromq4-1
@@ -86,14 +86,6 @@ fmt_clean :
 	@rm -rf fmt*
 	@rm -rf $(FMT_PACKAGE)
 
-$(IMAGEMAGICK_PACKAGE) : $(CLANG_PACKAGE)
-	./build.py $(BUILD_OPTIONS) imagemagick > imagemagick.log 2>&1
-imagemagick : $(IMAGEMAGICK_PACKAGE)
-imagemagick_clean :
-	@echo "Cleaning imagemagick..."
-	@rm -rf imagemagick*
-	@rm -rf $(IMAGEMAGICK_PACKAGE)
-
 $(JSON_PACKAGE) : $(CMAKE_PACKAGE)
 	./build.py $(BUILD_OPTIONS) json > json.log 2>&1
 json : $(JSON_PACKAGE)
@@ -174,7 +166,7 @@ zeromq4-1_clean :
 	@rm -rf zeromq4-1*
 	@rm -rf $(ZEROMQ4-1_PACKAGE)
 
-clean : avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean fmt_clean imagemagick_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean qpid-proton_clean redis_clean spdlog_clean zeromq4-1_clean
+clean : avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean fmt_clean json_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean qpid-proton_clean redis_clean spdlog_clean zeromq4-1_clean
 	@echo "Cleaning generated files..."
 	@rm -rf packages.mk
 	@echo "Done."

--- a/versions.json
+++ b/versions.json
@@ -151,22 +151,6 @@
         ],
         "fpm_directories": ["include", "lib"]
     },
-    "imagemagick": {
-        "commitish": "7.0.8-2",
-        "version_string": "7.0.8",
-        "license": "Apache License 2.0",
-        "consortium_build_number": "0",
-        "externals_root": "opt/irods-externals",
-        "build_steps": [
-            "./configure --prefix=TEMPLATE_INSTALL_PREFIX --exec-prefix=TEMPLATE_INSTALL_PREFIX --libdir=TEMPLATE_INSTALL_PREFIX/lib",
-            "make -jTEMPLATE_JOBS",
-            "make install"
-        ],
-        "external_build_steps": [
-            "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
-        ],
-        "fpm_directories": ["bin","etc","include","lib","share"]
-    },
     "json": {
         "commitish": "v3.10.4",
         "version_string": "3.10.4",


### PR DESCRIPTION
We only use imagemagick in the training repo, but we don't use the externals package. Let's get rid of it.