### PR TITLE
[irods/irods#7191] Tweaks for EL 9 support

### DIFF
--- a/build.py
+++ b/build.py
@@ -104,12 +104,7 @@ def run_cmd(cmd, run_env=False, unsafe_shell=False, check_rc=False, retries=0):
     return p.returncode
 
 def get_distribution_name():
-    log = logging.getLogger(__name__)
-    cmd = ['lsb_release','-s','-c']
-    p = subprocess.Popen(cmd, env=os.environ.copy(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (d, err) = p.communicate()
-    log.debug('linux distribution name detected: {0}'.format(d.strip()))
-    return d.strip().decode('utf-8')
+    return distro.codename()
 
 def get_package_filename(p):
     v = get_versions()[p]


### PR DESCRIPTION
In service of irods/irods#7191

I've tested building for Rocky 9 and Centos 7 and things seem okay.

We may not need lsb-release at all anymore thanks to `distro`, but I left it in for EL versions <9 just in case.