### PR TITLE
[#206] Remove pistache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all : avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq fmt json jwt-cpp libarchive libs3 mungefs nanodbc pistache qpid-proton redis spdlog zeromq4-1
+all : avro aws-sdk-cpp boost catch2 clang clang-runtime cmake cppzmq fmt json jwt-cpp libarchive libs3 mungefs nanodbc qpid-proton redis spdlog zeromq4-1
 
 
 server : avro boost catch2 clang-runtime cppzmq fmt json libarchive nanodbc spdlog zeromq4-1
@@ -134,14 +134,6 @@ nanodbc_clean :
 	@rm -rf nanodbc*
 	@rm -rf $(NANODBC_PACKAGE)
 
-$(PISTACHE_PACKAGE) : $(CLANG_PACKAGE)
-	./build.py $(BUILD_OPTIONS) pistache > pistache.log 2>&1
-pistache : $(PISTACHE_PACKAGE)
-pistache_clean :
-	@echo "Cleaning pistache..."
-	@rm -rf pistache*
-	@rm -rf $(PISTACHE_PACKAGE)
-
 $(QPID-PROTON_PACKAGE) : $(CLANG_PACKAGE)
 	./build.py $(BUILD_OPTIONS) qpid-proton > qpid-proton.log 2>&1
 qpid-proton : $(QPID-PROTON_PACKAGE)
@@ -174,7 +166,7 @@ zeromq4-1_clean :
 	@rm -rf zeromq4-1*
 	@rm -rf $(ZEROMQ4-1_PACKAGE)
 
-clean : avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean fmt_clean json_clean jwt-cpp_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean pistache_clean qpid-proton_clean redis_clean spdlog_clean zeromq4-1_clean
+clean : avro_clean aws-sdk-cpp_clean boost_clean catch2_clean clang_clean clang-runtime_clean cmake_clean cppzmq_clean fmt_clean json_clean jwt-cpp_clean libarchive_clean libs3_clean mungefs_clean nanodbc_clean qpid-proton_clean redis_clean spdlog_clean zeromq4-1_clean
 	@echo "Cleaning generated files..."
 	@rm -rf packages.mk
 	@echo "Done."

--- a/versions.json
+++ b/versions.json
@@ -254,23 +254,6 @@
         "deb_dependencies": ["libodbc1"],
         "rpm_dependencies": ["unixODBC"]
     },
-    "pistache": {
-        "commitish": "master",
-        "version_string": "0.0.2",
-        "license": "Apache 2.0",
-        "consortium_build_number": "0",
-        "externals_root": "opt/irods-externals",
-        "build_steps": [
-            "sed -i 's,\"pistache/string_view.h\",<string_view>,' ./include/pistache/router.h",
-            "mkdir -p build",
-            "cd build; rm -f CMakeCache.txt; TEMPLATE_CMAKE_EXECUTABLE -G'Unix Makefiles' -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_CXX_COMPILER=TEMPLATE_CLANGPP_EXECUTABLE -DCMAKE_C_COMPILER=TEMPLATE_CLANG_EXECUTABLE -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DCMAKE_CXX_FLAGS='-std=c++14 -nostdinc++ -ITEMPLATE_CLANG_CPP_HEADERS -Wno-sign-conversion' -DCMAKE_EXE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_SHARED_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_MODULE_LINKER_FLAGS='-stdlib=libc++ -LTEMPLATE_CLANG_CPP_LIBRARIES -lc++abi' -DCMAKE_BUILD_WITH_INSTALL_RPATH=True -DCMAKE_INSTALL_RPATH=/TEMPLATE_CLANG_RUNTIME_RPATH ..",
-            "cd build; make -jTEMPLATE_JOBS install"
-        ],
-        "external_build_steps": [
-            "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
-        ],
-        "fpm_directories": ["include", "lib"]
-    },
     "qpid-proton": {
         "commitish": "0.36.0",
         "version_string": "0.36.0",


### PR DESCRIPTION
Addresses #206

irods_client_rest_cpp is now deprecated and archived, so pistache is no longer needed or desired.