### PR TITLE
[#171,#199,#214,#215,#216,#217,#219] Introduce proper handling of package revision strings + Overhaul package dependency declaration management + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 Currently tested on:
 
-- Ubuntu 18
-- Ubuntu 20
+- Ubuntu 20.04
+- Ubuntu 22.04
 - CentOS 7
 - AlmaLinux 8
 - Rocky Linux 8
+- Rocky Linux 9
 - Debian 11
+- Debian 12
 
 # Assumptions
 
@@ -17,10 +19,11 @@ The automated scripts run commands as `sudo` and update system libraries and com
 
 In a new container, run the following:
 
-## Ubuntu 18, Ubuntu 20, and Debian 11
+## Ubuntu 20.04, Ubuntu 22.04, Debian 11, and Debian 12
 
 ```bash
-apt-get update -y && apt-get install -y sudo git python3 python3-distro
+apt-get update
+apt-get install -y sudo git python3 python3-distro
 ./install_prerequisites.py
 
 # The following lines apply to Ubuntu 20 only!!!
@@ -31,33 +34,44 @@ hash -r
 make # or "make server" for packages specific to building the iRODS server.
 ```
 
-## CentOS 7
+## RHEL / CentOS 7
 
 ```bash
-yum update -y && yum install -y sudo git python3 centos-release-scl
-yum install -y devtoolset-10-gcc devtoolset-10-gcc-c++
+yum install -y sudo git python3 centos-release-scl epel-release
+yum install -y python36-distro devtoolset-10-gcc devtoolset-10-gcc-c++
 
 # Installing the prerequistes must be done before enabling the GCC compiler
 # environment.
-python3 -m venv build_env
-source build_env/bin/activate
-python -m pip install distro
 ./install_prerequisites.py
 
 # Enable the GCC 10 compiler tools.
 scl enable devtoolset-10 bash
 
-# Although it appears that the python virtual environment has been deactivated,
-# trust and believe it is still active.
 make # or "make server" for packages specific to building the iRODS server.
 ```
 
-## AlmaLinux 8 and Rocky Linux 8
+## RHEL / AlmaLinux / Rocky Linux 8
 
 ```bash
-dnf update -y && dnf install -y sudo git python3 python3-distro gcc-toolset-11
+dnf config-manager --set-enabled powertools
+dnf install -y sudo git python3 python3-distro gcc-toolset-11
+
+# Installing the prerequistes must be done before enabling the GCC compiler
+# environment.
 ./install_prerequisites.py
+
+# Enable the GCC 11 compiler tools.
 scl enable gcc-toolset-11 bash
+
+make # or "make server" for packages specific to building the iRODS server.
+```
+
+## RHEL / AlmaLinux / Rocky Linux 9
+
+```bash
+dnf config-manager --set-enabled crb
+dnf install -y sudo git python3 python3-distro
+./install_prerequisites.py
 make # or "make server" for packages specific to building the iRODS server.
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently tested on:
 
 # Assumptions
 
-This repository is expected to build in a VM or container environment that is isolated from other software or build environments.
+This repository is expected to build in a VM or container environment that is isolated from other software or build environments. Pre-written dockerfiles can be found in the [development environment repository](https://github.com/irods/irods_development_environment/).
 
 The automated scripts run commands as `sudo` and update system libraries and compilers, etc.
 

--- a/versions.json
+++ b/versions.json
@@ -4,7 +4,7 @@
         "version_string": "1.11.0",
         "license": "Apache License 2.0",
         "consortium_build_number": "2",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p lang/c++/build",
@@ -15,14 +15,18 @@
             "cd lang/c++/build",
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["bin","include","lib"]
+        "fpm_directories": ["bin","include","lib"],
+        "interdependencies": [
+            "boost",
+            "clang-runtime"
+        ]
     },
     "aws-sdk-cpp": {
         "commitish": "1.9.323",
         "version_string": "1.9.323",
         "license": "Apache License 2.0",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -32,7 +36,53 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include","lib","lib64"]
+        "fpm_directories": ["include","lib","lib64"],
+        "interdependencies": [
+            "clang-runtime"
+        ],
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "libcurl",
+                    "zlib",
+                    "openssl-libs"
+                ],
+                "8": [
+                    "libcurl",
+                    "zlib",
+                    "openssl-libs"
+                ],
+                "9": [
+                    "libcurl",
+                    "zlib",
+                    "openssl-libs"
+                ]
+            },
+            "debian": {
+                "11": [
+                    "libcurl3-gnutls",
+                    "libz1",
+                    "libssl1.1"
+                ],
+                "12": [
+                    "libcurl3-gnutls",
+                    "libz1",
+                    "libssl3"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libcurl3-gnutls",
+                    "libz1",
+                    "libssl1.1"
+                ],
+                "22.04": [
+                    "libcurl3-gnutls",
+                    "libz1",
+                    "libssl3"
+                ]
+            }
+        }
     },
     "boost": {
         "git_repository": "https://github.com/boostorg/boost",
@@ -40,7 +90,7 @@
         "version_string": "1.81.0",
         "license": "Boost Software License 1.0",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "git submodule update --init",
@@ -51,7 +101,54 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include","lib"]
+        "fpm_directories": ["include","lib"],
+        "interdependencies": [
+            "clang-runtime"
+        ],
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "zlib",
+                    "bzip2-libs",
+                    "xz-libs"
+                ],
+                "8": [
+                    "zlib",
+                    "bzip2-libs",
+                    "xz-libs",
+                    "libzstd"
+                ],
+                "9": [
+                    "zlib",
+                    "bzip2-libs",
+                    "xz-libs"
+                ]
+            },
+            "debian": {
+                "11": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libicu67"
+                ],
+                "12": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libicu72"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libicu66"
+                ],
+                "22.04": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libicu70"
+                ]
+            }
+        }
     },
     "catch2": {
         "commitish": "v2.13.8",
@@ -75,7 +172,7 @@
         "version_string": "13.0.0",
         "license": "LLVM",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE=TEMPLATE_PYTHON_EXECUTABLE -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;' ../llvm-project/llvm",
@@ -88,7 +185,57 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["bin","include","lib","share"]
+        "fpm_directories": ["bin","include","lib","share"],
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "zlib",
+                    "libstdc++",
+                    "ncurses-libs",
+                    "libxml2"
+                ],
+                "8": [
+                    "zlib",
+                    "libstdc++",
+                    "ncurses-libs",
+                    "libxml2"
+                ],
+                "9": [
+                    "zlib",
+                    "libstdc++",
+                    "ncurses-libs",
+                    "libxml2"
+                ]
+            },
+            "debian": {
+                "11": [
+                    "libz1",
+                    "libstdc++6",
+                    "libtinfo6",
+                    "libxml2"
+                ],
+                "12": [
+                    "libz1",
+                    "libstdc++6",
+                    "libtinfo6",
+                    "libxml2"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libz1",
+                    "libstdc++6",
+                    "libtinfo6",
+                    "libxml2"
+                ],
+                "22.04": [
+                    "libz1",
+                    "libstdc++6",
+                    "libtinfo6",
+                    "libxml2"
+                ]
+            }
+        }
     },
     "clang-runtime": {
         "commitish": "not-used-same-as-clang",
@@ -114,7 +261,7 @@
         "version_string": "3.21.4",
         "license": "BSD 3-Clause",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "./configure --prefix=TEMPLATE_INSTALL_PREFIX --parallel=TEMPLATE_JOBS",
@@ -124,14 +271,61 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["bin","doc","share"]
+        "fpm_directories": ["bin","doc","share"],
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "libstdc++",
+                    "ncurses-libs",
+                    "openssl-libs"
+                ],
+                "8": [
+                    "libstdc++",
+                    "ncurses-libs",
+                    "openssl-libs"
+                ],
+                "9": [
+                    "libstdc++",
+                    "ncurses-libs",
+                    "openssl-libs"
+                ]
+            },
+            "debian": {
+                "11": [
+                    "libncurses6",
+                    "libstdc++6",
+                    "libssl1.1",
+                    "libtinfo6"
+                ],
+                "12": [
+                    "libncurses6",
+                    "libstdc++6",
+                    "libssl3",
+                    "libtinfo6"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libncurses6",
+                    "libstdc++6",
+                    "libssl1.1",
+                    "libtinfo6"
+                ],
+                "22.04": [
+                    "libncurses6",
+                    "libstdc++6",
+                    "libssl3",
+                    "libtinfo6"
+                ]
+            }
+        }
     },
     "cppzmq": {
         "commitish": "v4.8.1",
         "version_string": "4.8.1",
         "license": "LGPL v3",
         "consortium_build_number": "1",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -141,14 +335,17 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include","lib"]
+        "fpm_directories": ["include","lib"],
+        "interdependencies": [
+            "zeromq4-1"
+        ]
     },
     "fmt": {
         "commitish": "8.1.1",
         "version_string": "8.1.1",
         "license": "MIT",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -158,7 +355,10 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include", "lib"]
+        "fpm_directories": ["include", "lib"],
+        "interdependencies": [
+            "clang-runtime"
+        ]
     },
     "json": {
         "commitish": "v3.10.4",
@@ -183,7 +383,7 @@
         "version_string": "0.6.99.0",
         "license": "MIT",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -193,14 +393,17 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include","lib"]
+        "fpm_directories": ["include","lib"],
+        "interdependencies": [
+            "json"
+        ]
     },
     "libarchive": {
         "commitish": "v3.5.2",
         "version_string": "3.5.2",
         "license": "BSD 2-Clause",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "TEMPLATE_CMAKE_EXECUTABLE -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_C_FLAGS:STRING=-fPIC -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX .",
@@ -211,14 +414,67 @@
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
         "fpm_directories": ["bin","include","lib","share"],
-        "rpm_dependencies": ["xz-libs >= 5.2.2"]
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "zlib",
+                    "bzip2-libs",
+                    "openssl-libs",
+                    "libxml2",
+                    "xz-libs >= 5.2.2"
+                ],
+                "8": [
+                    "zlib",
+                    "bzip2-libs",
+                    "openssl-libs",
+                    "libxml2",
+                    "xz-libs >= 5.2.2",
+                    "libzstd"
+                ],
+                "9": [
+                    "zlib",
+                    "bzip2-libs",
+                    "openssl-libs",
+                    "libxml2",
+                    "xz-libs >= 5.2.2"
+                ]
+            },
+            "debian": {
+                "11": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libssl1.1",
+                    "libxml2"
+                ],
+                "12": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libssl3",
+                    "libxml2"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libssl1.1",
+                    "libxml2"
+                ],
+                "22.04": [
+                    "libz1",
+                    "libbz2-1.0",
+                    "libssl3",
+                    "libxml2"
+                ]
+            }
+        }
     },
     "mungefs": {
         "commitish": "1.0.7",
         "version_string": "1.0.7",
         "license": "BSD 3-Clause",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -228,14 +484,50 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["bin"]
+        "fpm_directories": ["bin"],
+        "interdependencies": [
+            "clang-runtime",
+            "boost",
+            "libarchive",
+            "avro",
+            "zeromq4-1"
+        ],
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "fuse-libs"
+                ],
+                "8": [
+                    "fuse-libs"
+                ],
+                "9": [
+                    "fuse-libs"
+                ]
+            },
+            "debian": {
+                "11": [
+                    "libfuse2"
+                ],
+                "12": [
+                    "libfuse2"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libfuse2"
+                ],
+                "22.04": [
+                    "libfuse2"
+                ]
+            }
+        }
     },
     "nanodbc": {
         "commitish": "v2.13.0",
         "version_string": "2.13.0",
         "license": "MIT",
         "consortium_build_number": "1",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -246,15 +538,45 @@
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
         "fpm_directories": ["include", "lib"],
-        "deb_dependencies": ["libodbc1"],
-        "rpm_dependencies": ["unixODBC"]
+        "interdependencies": [
+            "clang-runtime"
+        ],
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "unixODBC"
+                ],
+                "8": [
+                    "unixODBC"
+                ],
+                "9": [
+                    "unixODBC"
+                ]
+            },
+            "debian": {
+                "1": [
+                    "libodbc1"
+                ],
+                "12": [
+                    "libodbc2"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libodbc1"
+                ],
+                "22.04": [
+                    "libodbc2"
+                ]
+            }
+        }
     },
     "qpid-proton": {
         "commitish": "0.36.0",
         "version_string": "0.36.0",
         "license": "Apache License 2.0",
         "consortium_build_number": "1",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -264,7 +586,39 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include", "lib"]
+        "fpm_directories": ["include", "lib"],
+        "interdependencies": [
+            "clang-runtime"
+        ],
+        "distro_dependencies": {
+            "rhel": {
+                "7": [
+                    "openssl-libs"
+                ],
+                "8": [
+                    "openssl-libs"
+                ],
+                "9": [
+                    "openssl-libs"
+                ]
+            },
+            "debian": {
+                "11": [
+                    "libssl1.1"
+                ],
+                "12": [
+                    "libssl3"
+                ]
+            },
+            "ubuntu": {
+                "20.04": [
+                    "libssl1.1"
+                ],
+                "22.04": [
+                    "libssl3"
+                ]
+            }
+        }
     },
     "redis": {
         "commitish": "4.0.10",
@@ -287,7 +641,7 @@
         "version_string": "1.9.2",
         "license": "MIT",
         "consortium_build_number": "1",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -297,14 +651,17 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["include","lib"]
+        "fpm_directories": ["include","lib"],
+        "interdependencies": [
+            "fmt"
+        ]
     },
     "zeromq4-1": {
         "commitish": "v4.1.8",
         "version_string": "4.1.8",
         "license": "LGPL v3",
         "consortium_build_number": "0",
-        "package_revision": "2",
+        "package_revision": "3",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -314,6 +671,9 @@
         "external_build_steps": [
             "ls -l TEMPLATE_INSTALL_PREFIX/../* ; cp -rf TEMPLATE_INSTALL_PREFIX/../* ../../ ; ls -l ../../"
         ],
-        "fpm_directories": ["bin","include","lib"]
+        "fpm_directories": ["bin","include","lib"],
+        "interdependencies": [
+            "clang-runtime"
+        ]
     }
 }

--- a/versions.json
+++ b/versions.json
@@ -4,6 +4,7 @@
         "version_string": "1.11.0",
         "license": "Apache License 2.0",
         "consortium_build_number": "2",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p lang/c++/build",
@@ -21,6 +22,7 @@
         "version_string": "1.9.323",
         "license": "Apache License 2.0",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -38,6 +40,7 @@
         "version_string": "1.81.0",
         "license": "Boost Software License 1.0",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "git submodule update --init",
@@ -55,6 +58,7 @@
         "version_string": "2.13.8",
         "license": "Boost Software License 1.0",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -71,6 +75,7 @@
         "version_string": "13.0.0",
         "license": "LLVM",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "TEMPLATE_CMAKE_EXECUTABLE -G 'Unix Makefiles' -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX -DPYTHON_EXECUTABLE=TEMPLATE_PYTHON_EXECUTABLE -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi;clang-tools-extra;compiler-rt;' ../llvm-project/llvm",
@@ -90,6 +95,7 @@
         "version_string": "13.0.0",
         "license": "LLVM",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p TEMPLATE_INSTALL_PREFIX/lib",
@@ -108,6 +114,7 @@
         "version_string": "3.21.4",
         "license": "BSD 3-Clause",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "./configure --prefix=TEMPLATE_INSTALL_PREFIX --parallel=TEMPLATE_JOBS",
@@ -124,6 +131,7 @@
         "version_string": "4.8.1",
         "license": "LGPL v3",
         "consortium_build_number": "1",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -140,6 +148,7 @@
         "version_string": "8.1.1",
         "license": "MIT",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -156,6 +165,7 @@
         "version_string": "3.10.4",
         "license": "MIT",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -173,6 +183,7 @@
         "version_string": "0.6.99.0",
         "license": "MIT",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -189,6 +200,7 @@
         "version_string": "3.5.2",
         "license": "BSD 2-Clause",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "TEMPLATE_CMAKE_EXECUTABLE -DCMAKE_USER_MAKE_RULES_OVERRIDE=TEMPLATE_SCRIPT_PATH/ClangOverrides.txt -DCMAKE_C_FLAGS:STRING=-fPIC -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=TEMPLATE_INSTALL_PREFIX .",
@@ -206,6 +218,7 @@
         "version_string": "1.0.7",
         "license": "BSD 3-Clause",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -222,6 +235,7 @@
         "version_string": "2.13.0",
         "license": "MIT",
         "consortium_build_number": "1",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -240,6 +254,7 @@
         "version_string": "0.36.0",
         "license": "Apache License 2.0",
         "consortium_build_number": "1",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -256,6 +271,7 @@
         "version_string": "4.0.10",
         "license": "BSD 3-Clause",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "make -jTEMPLATE_JOBS",
@@ -271,6 +287,7 @@
         "version_string": "1.9.2",
         "license": "MIT",
         "consortium_build_number": "1",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",
@@ -287,6 +304,7 @@
         "version_string": "4.1.8",
         "license": "LGPL v3",
         "consortium_build_number": "0",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "build_steps": [
             "mkdir -p build",


### PR DESCRIPTION
Addresses #171
Addresses #199
Addresses #214
Addresses #215
Addresses #216
Addresses #217
Addresses #219

This PR introduces a `get_package_filename` function to `build.py` that generates the full package version, including a package revision string, which we have not been supplying until this point. This package revision string contains the distro codename for deb-based distros, and the EL major version for rpm-based distros.

A `package_revision` entry is now supported in versions.json, to specify the base package revision, to which the distro-specific suffix will be appended. If the entry is not present, "0" will be assumed.

Despite the fact that we have not been supplying package revision strings until now, "2" was chosen as the `package_revision` starting point for all current packages, as our rpm packages have contained a false package revision of "1" in their filenames.

Additionally, some package dependency declaration management functionality has been introduced.

Externals packages can now declare dependencies on each other via a new `interdependencies` array, and dependencies on distro-provided packages via a new `distro_dependencies` object. This replaces the `rpm_dependencies` and `deb_dependencies` arrays.
I've also populated these fields for our existing packages.

I also slipped in an update to the README.

Merge irods/irods_development_environment#124 first
