### PR TITLE
[#260] Fix invalid escape sequences in clang package's python files

### DIFF
--- a/patches/clang/1006-clang-tools-extra-py-fix-invalid-escape-sequences.patch
+++ b/patches/clang/1006-clang-tools-extra-py-fix-invalid-escape-sequences.patch
@@ -1,0 +1,47 @@
+fix(clang-tools-extra/**.py): fix invalid escape sequences
+
+Based on commit d63be475e889ba3361799f6907b3c95354684c7d from upstream.
+Upstream commit Author: Eisuke Kawashima <e.kawaschima+github@gmail.com>
+Upstream commit Author Date: Tue, 11 Jun 2024 04:05:40 +0900
+Upstream commit Committer: Piotr Zegar <me@piotrzegar.pl>
+Upstream commit Commit Date: Mon, 10 Jun 2024 21:05:40 +0200
+---
+ clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py                 |    4 ++--
+ clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py |    2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff -pru llvm-project.orig/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+--- llvm-project.orig/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py	2024-12-04 18:23:06.038522255 -0500
++++ llvm-project/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py	2024-12-04 18:29:38.919426287 -0500
+@@ -172,7 +172,7 @@ def main():
+   filename = None
+   lines_by_file = {}
+   for line in sys.stdin:
+-    match = re.search('^\+\+\+\ \"?(.*?/){%s}([^ \t\n\"]*)' % args.p, line)
++    match = re.search('^\\+\\+\\+\\ \"?(.*?/){%s}([^ \t\n\"]*)' % args.p, line)
+     if match:
+       filename = match.group(2)
+     if filename is None:
+@@ -185,7 +185,7 @@ def main():
+       if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
+         continue
+ 
+-    match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
++    match = re.search(r'^@@.*\+(\d+)(,(\d+))?', line)
+     if match:
+       start_line = int(match.group(1))
+       line_count = 1
+diff -pru llvm-project.orig/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py llvm-project/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py
+--- llvm-project.orig/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py	2024-12-04 18:23:06.166522549 -0500
++++ llvm-project/clang-tools-extra/docs/clang-tidy/checks/gen-static-analyzer-docs.py	2024-12-04 18:30:28.843541054 -0500
+@@ -44,7 +44,7 @@ def get_checkers(checkers_td_directory):
+       parent_package_ = parent_package["ParentPackage"]
+ 
+     full_package_name = "clang-analyzer-" + checker_package_prefix + "." + checker_name
+-    anchor_url = re.sub("\.", "-", checker_package_prefix + "." + checker_name).lower()
++    anchor_url = re.sub(r"\.", "-", checker_package_prefix + "." + checker_name).lower()
+ 
+     if(not hidden and "alpha" not in full_package_name.lower()):
+       checker["FullPackageName"] = full_package_name
+-- 
+

--- a/patches/clang/1007-opt-viewer-fix-invalid-escape-sequence.patch
+++ b/patches/clang/1007-opt-viewer-fix-invalid-escape-sequence.patch
@@ -1,0 +1,19 @@
+Fix one more invalid escape sequence that makes it into the package
+---
+ llvm/tools/opt-viewer/opt-viewer.py |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff -pru llvm-project.orig/llvm/tools/opt-viewer/opt-viewer.py llvm-project/llvm/tools/opt-viewer/opt-viewer.py
+--- llvm-project.orig/llvm/tools/opt-viewer/opt-viewer.py	2024-12-04 18:23:16.754546940 -0500
++++ llvm-project/llvm/tools/opt-viewer/opt-viewer.py	2024-12-04 19:10:24.893308338 -0500
+@@ -115,7 +115,7 @@ class SourceFileRenderer:
+         # Column is the number of characters *including* tabs, keep those and
+         # replace everything else with spaces.
+         indent = line[:max(r.Column, 1) - 1]
+-        indent = re.sub('\S', ' ', indent)
++        indent = re.sub(r'\S', ' ', indent)
+ 
+         # Create expanded message and link if we have a multiline message.
+         lines = r.message.split('\n')
+-- 
+

--- a/versions.json
+++ b/versions.json
@@ -343,7 +343,7 @@
         "version_string": "13.0.1",
         "license": "Apache-2.0 WITH LLVM-exception",
         "consortium_build_number": "0",
-        "package_revision": "1",
+        "package_revision": "2",
         "externals_root": "opt/irods-externals",
         "patches": [
             "clang/from-debian/declare_clear_cache.diff",
@@ -384,7 +384,9 @@
             "clang/1002-libcxx-Prefer-__has_builtin-for-detecting-compiler-p.patch",
             "clang/1003-more-__has_builtin-replacements.patch",
             "clang/1004-libcxx-Use-__is_convertible-built-in-when-available.patch",
-            "clang/1005-libcxx-fix-remove_reference_t.patch"
+            "clang/1005-libcxx-fix-remove_reference_t.patch",
+            "clang/1006-clang-tools-extra-py-fix-invalid-escape-sequences.patch",
+            "clang/1007-opt-viewer-fix-invalid-escape-sequence.patch"
         ],
         "build_steps": [
             "mkdir -p ../build",


### PR DESCRIPTION
Addresses #260

Not yet tested, so PR is in draft mode